### PR TITLE
made sidebar more reusable

### DIFF
--- a/Frontend/src/components/sideBar.jsx
+++ b/Frontend/src/components/sideBar.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Box, Typography, Slider, FormControl, Select, MenuItem, Checkbox, FormControlLabel, FormGroup,InputLabel } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
-
+import PropTypes from 'prop-types';
 // Create a theme
 const theme = createTheme({
   typography: {
@@ -26,13 +26,15 @@ const theme = createTheme({
           color: 'white',
           marginLeft: '1vw',
           marginTop: '2vw',
+          visibility:true,
+          display:true,
         },
       },
     },
   },
 });
 
-const SideBar = () => {
+const SideBar = (props) => {
   const styleBoxRef = useRef(null);
 
   useEffect(() => {
@@ -63,43 +65,10 @@ const SideBar = () => {
     borderRadius: '15px'
   };
 
-  // Define the marks for RAM slider
-  const ram_marks = [
-    { value: 0, label: '0GB' },
-    { value: 16, label: '16GB' },
-    { value: 32, label: '32GB' },
-    { value: 48, label: '48GB' }
-  ];
-
-  // Define the marks for SSD slider
-  const ssd_marks = [
-    { value: 500, label: '0.5TB' },
-    { value: 1000, label: '1TB' },
-    { value: 1500, label: '1.5TB' },
-    { value: 2000, label: '2TB' },
-    { value: 2500, label: '<2.5TB' }
-  ];
-
-  // Define the marks for Price slider
-  const price = [
-    { value: 500, label: '500$' },
-    { value: 1000 },
-    { value: 1500 },
-    { value: 2000 },
-    { value: 2500, label: '<2500$' }
-  ];
-
-  // Define the marks for VRAM slider
-  const vram_marks = [
-    { value: 2, label: '2GB' },
-    { value: 4 },
-    { value: 6 },
-    { value: 8 },
-    { value: 12, label: '12GB' }
-  ];
+ 
 
   function valuetext(value) {
-    return `${value}GB`;
+    return `${value}`;
   }
 
   return (
@@ -109,29 +78,29 @@ const SideBar = () => {
           <Typography variant="h3" style={{ textAlign: 'center', marginTop: '0.5vh' }}>Filters</Typography>
 
           <FormControl fullWidth margin="normal" style={{ marginTop: '1vh' }}>
-            <InputLabel style={{ color: 'white' }}>CPU</InputLabel>
+            <InputLabel style={{ color: 'white' }}>{props.dropdown1.label}</InputLabel>
             <Select
               sx={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', menuProps: { style: { backgroundColor: 'rgba(53, 14, 88, 0.5)' } }, borderBlockColor: 'white', '& .MuiSelect-icon': { color: 'white' }, '& fieldset': { borderColor: 'white' } }}
             >
-              <MenuItem value="Intel" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)' }}>INTEL</MenuItem>
-              <MenuItem value="AMD" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)' }}>AMD</MenuItem>
+              <MenuItem value="Intel" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)' }}>{props.dropdown1.opt1}</MenuItem>
+              <MenuItem value="AMD" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)' }}>{props.dropdown1.opt2}</MenuItem>
               {/* Add more CPU options here */}
             </Select>
           </FormControl>
 
           <FormControl fullWidth margin="normal">
-            <InputLabel style={{ color: 'white' }}>GPU</InputLabel>
+            <InputLabel style={{ color: 'white' }}>{props.dropdown2.label}</InputLabel>
             <Select
               sx={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', menuProps: { style: { backgroundColor: 'rgba(53, 14, 88, 0.5)' } }, borderBlockColor: 'white', '& .MuiSelect-icon': { color: 'white' }, '& fieldset': { borderColor: 'white' } }}
             >
-              <MenuItem value="gpu1" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', textAlign: 'center' }}>GeForce RTX Series</MenuItem>
-              <MenuItem value="gpu2" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', textAlign: 'center' }}>AMD RX series</MenuItem>
+              <MenuItem value="gpu1" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', textAlign: 'center' }}> {props.dropdown2.opt1}</MenuItem>
+              <MenuItem value="gpu2" style={{ color: 'white', backgroundColor: 'rgba(53, 14, 88, 0.5)', textAlign: 'center' }}>{props.dropdown2.opt2}</MenuItem>
               {/* Add more GPU options here */}
             </Select>
           </FormControl>
 
           <FormControl fullWidth margin="normal" style={{ marginLeft: '1.5vw' }}>
-            <Slider defaultValue={2} getAriaValueText={valuetext} step={16} min={0} max={48} valueLabelDisplay="auto" marks={ram_marks} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
+            <Slider defaultValue={2} getAriaValueText={valuetext} step={props.label1.step} min={props.label1.min} max={props.label1.max} valueLabelDisplay="auto" markLabel='visible' marks={props.label1.mark} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
             <InputLabel
               sx={{
                 color: 'white',
@@ -139,11 +108,11 @@ const SideBar = () => {
                 fontSize: '1.5rem'
               }}
             >
-              RAM
+              {props.label1.title}
             </InputLabel>
           </FormControl>
           <FormControl fullWidth margin="normal" style={{ marginLeft: '1.5vw', marginTop: '4vh' }}>
-            <Slider defaultValue={500} getAriaValueText={valuetext} step={500} min={500} max={2500} valueLabelDisplay="auto" marks={ssd_marks} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
+            <Slider defaultValue={500} getAriaValueText={valuetext} step={props.label2.step} min={props.label2.min} max={props.label2.max} valueLabelDisplay="off" marks={props.label2.mark} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
             <InputLabel
               sx={{
                 color: 'white',
@@ -151,25 +120,12 @@ const SideBar = () => {
                 fontSize: '1.5rem'
               }}
             >
-              Storage
-            </InputLabel>
-          </FormControl>
-
-          <FormControl fullWidth margin="normal" style={{ marginLeft: '1.5vw', marginTop: '4vh' }}>
-            <Slider defaultValue={2} getAriaValueText={valuetext} step={500} min={500} max={2500} valueLabelDisplay="auto" marks={price} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
-            <InputLabel
-              sx={{
-                color: 'white',
-                textAlign: 'center',
-                fontSize: '1.5rem'
-              }}
-            >
-              Price
+              {props.label2.title}
             </InputLabel>
           </FormControl>
 
           <FormControl fullWidth margin="normal" style={{ marginLeft: '1.5vw', marginTop: '4vh' }}>
-            <Slider defaultValue={2} getAriaValueText={valuetext} step={2} min={2} max={12} valueLabelDisplay="auto" marks={vram_marks} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
+            <Slider defaultValue={2} getAriaValueText={valuetext} step={props.label3.step} min={props.label3.min} max={props.label3.max} valueLabelDisplay="auto" marks={props.label3.mark} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
             <InputLabel
               sx={{
                 color: 'white',
@@ -177,13 +133,26 @@ const SideBar = () => {
                 fontSize: '1.5rem'
               }}
             >
-              VRAM
+              {props.label3.title}
+            </InputLabel>
+          </FormControl>
+
+          <FormControl fullWidth margin="normal" style={{ marginLeft: '1.5vw', marginTop: '4vh' }}>
+            <Slider defaultValue={2} getAriaValueText={valuetext} step={props.label4.step} min={props.label4.min} max={props.label4.max} valueLabelDisplay="auto" marks={props.label4.mark} style={{ width: '20vw', '& .MuiSlider-markLabel': { color: 'white' } }} />
+            <InputLabel
+              sx={{
+                color: 'white',
+                textAlign: 'center',
+                fontSize: '1.5rem'
+              }}
+            >
+              {props.label4.title}              
             </InputLabel>
           </FormControl>
 
           <FormGroup style={{ marginLeft: '2vw', marginTop: '5vh', fontSize:'2rem' }}>
-            <Typography variant="subtitle1" style={{ color: 'white',fontSize:'2rem'  }}>Categories</Typography>
-            {categories.map((category) => (
+            <Typography variant="subtitle1" style={{ color: 'white',fontSize:'2rem'  }}>{props.categories}</Typography>
+            {props.cat_titles.map((category) => (
               <FormControlLabel key={category} control={<Checkbox name={category} style={{ color: '#BB84EC',fontSize:'2rem' }} />} label={category} />
             ))}
           </FormGroup>
@@ -194,3 +163,16 @@ const SideBar = () => {
 };
 
 export default SideBar; // Remove the colon after SideBar
+
+SideBar.propTypes={
+  label1: PropTypes.object.isRequired,
+  label2: PropTypes.object.isRequired,
+  label3: PropTypes.object.isRequired,
+  label4: PropTypes.object.isRequired,
+  categories: PropTypes.string.isRequired,
+  cat_titles: PropTypes.array.isRequired,
+  dropdown1: PropTypes.object.isRequired,
+  dropdown2: PropTypes.object.isRequired,
+}
+
+

--- a/Frontend/src/pages/prebuiltPC.jsx
+++ b/Frontend/src/pages/prebuiltPC.jsx
@@ -43,9 +43,82 @@ const prebuiltPC = () => {
     backgroundColor:'#373538',
   });
   
-  
-  
+   // Define the marks for RAM slider
+   const step_16_gb = [
+    { value: 0, label: '0GB' },
+    { value: 16, label: '16GB' },
+    { value: 32, label: '32GB' },
+    { value: 48, label: '48GB' }
+  ];
 
+  // Define the marks for SSD slider
+  const ssd_marks = [
+    { value: 500, label: '0.5TB' },
+    { value: 1000, label: '1TB' },
+    { value: 1500, label: '1.5TB' },
+    { value: 2000, label: '2TB' },
+    { value: 2500, label: '<2.5TB' }
+  ];
+
+  // Define the marks for Price slider
+  const price = [
+    { value: 500, label: '500$' },
+    { value: 1000,label: ' ' },
+    { value: 1500,label: ' ' },
+    { value: 2000,label: ' ' },
+    { value: 2500, label: '<2500$' }
+  ];
+
+  // Define the marks for VRAM slider
+  const vram_marks = [
+    { value: 2, label: '2GB' },
+    { value: 4, label: ' ' },
+    { value: 6, label: ' ' },
+    { value: 8, label: ' ' },
+    { value: 12, label: '12GB' }
+  ];
+  
+  const ram={
+    title:'RAM',
+    marks:step_16_gb,
+    min:0,
+    max:48,
+    step:16
+  }
+  const vram={
+    title:'VRAM',
+    marks:vram_marks,
+    min:2,
+    max:12,
+    step:12
+  }
+  const price_det={
+    title:'Price',
+    marks:price,
+    min:500,
+    max:2500,
+    step:500,
+  }
+  const ssd={
+    title:'Storage',
+    marks:ssd_marks,
+    min:500,
+    max:2500,
+    step:500,
+  }
+
+  const cat_titles=['Nimble','Edge','Titan']
+  const categories='Model'
+  const Cpu={
+    label:'CPU',
+    opt1:'Intel',
+    opt2:'AMD',
+  }
+  const gpu={
+    label:'GPU',
+    opt1:'Ge Force RTX',
+    opt2:'Radeon RX',
+  }
   return (
     <ThemeProvider theme={theme}>
       {/* Background image container */}
@@ -57,7 +130,7 @@ const prebuiltPC = () => {
         `}
       </style>
       <div style={containerStyle}>
-        <SideBar />
+        <SideBar label1={price_det} label2={ram} label3={vram} label4={ssd} dropdown1={Cpu} dropdown2={gpu} categories={categories} cat_titles={cat_titles}/>
         <div style={productCardStyle}>
           <Stack direction="row" spacing={'0.5vw'} style={stackStyle}>
             <ProductCard />


### PR DESCRIPTION
Theres a slight problem with the sliders in that the earlier visible mark label is not visible anymore after passing props to make the overall component more re usable across pages but rest everything is the same if u have any ideas on how to make it visible i am all ears i have tried every solution i could find with no solution